### PR TITLE
fix: optimize ensureProjectExists to use only upsert (closes #58)

### DIFF
--- a/src/core/adapters/mock/projectRepository.ts
+++ b/src/core/adapters/mock/projectRepository.ts
@@ -13,6 +13,7 @@ export class MockProjectRepository implements ProjectRepository {
   private projects: Map<ProjectId, Project> = new Map();
   private nextId = 1;
   private shouldFailList = false;
+  private shouldFailUpsert = false;
 
   constructor(initialProjects: Project[] = []) {
     for (const project of initialProjects) {
@@ -23,6 +24,10 @@ export class MockProjectRepository implements ProjectRepository {
   async upsert(
     params: CreateProjectParams,
   ): Promise<Result<Project, RepositoryError>> {
+    if (this.shouldFailUpsert) {
+      return err(new RepositoryError("Mock repository upsert failure"));
+    }
+
     // Check if project with same path already exists
     const existingProject = Array.from(this.projects.values()).find(
       (project) => project.path === params.path,
@@ -153,6 +158,7 @@ export class MockProjectRepository implements ProjectRepository {
     this.projects.clear();
     this.nextId = 1;
     this.shouldFailList = false;
+    this.shouldFailUpsert = false;
   }
 
   getAll(): Project[] {
@@ -168,5 +174,9 @@ export class MockProjectRepository implements ProjectRepository {
 
   setShouldFailList(shouldFail: boolean): void {
     this.shouldFailList = shouldFail;
+  }
+
+  setShouldFailUpsert(shouldFail: boolean): void {
+    this.shouldFailUpsert = shouldFail;
   }
 }

--- a/src/core/application/watcher/processLogFile.test.ts
+++ b/src/core/application/watcher/processLogFile.test.ts
@@ -152,7 +152,7 @@ describe("processLogFile", () => {
       const existingProject = {
         id: projectIdSchema.parse("existing-project-id"),
         name: projectName,
-        path: "/path/to/existing-project",
+        path: projectName, // path should match the projectName for upsert to work correctly
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -317,7 +317,7 @@ describe("processLogFile", () => {
       };
 
       mockLogParser.setParsedFile(filePath, parsedFile);
-      mockProjectRepository.setShouldFailList(true);
+      mockProjectRepository.setShouldFailUpsert(true);
 
       // Act
       const result = await processLogFile(context, {
@@ -329,7 +329,9 @@ describe("processLogFile", () => {
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
         expect(result.error.type).toBe("PROCESS_LOG_FILE_ERROR");
-        expect(result.error.message).toContain("Failed to list projects");
+        expect(result.error.message).toContain(
+          "Failed to ensure project exists",
+        );
       }
     });
 
@@ -593,7 +595,7 @@ describe("processLogFile", () => {
       const existingProject = {
         id: projectId,
         name: "existing-name-project",
-        path: "/path/to/existing-name-project",
+        path: "existing-name-project", // path should match the projectName for upsert to work correctly
         createdAt: new Date(),
         updatedAt: new Date(),
       };


### PR DESCRIPTION
## Summary

- Simplify `ensureProjectExists` function from 90 lines to 25 lines
- Eliminate unnecessary database calls: `list → upsert → list` to single `upsert`
- Leverage database's built-in conflict resolution (`ON CONFLICT DO UPDATE`) for better performance
- Update mock repository and tests to support new implementation

## Performance Improvements

**Before**: 3 database roundtrips
1. `list()` to check if project exists
2. `upsert()` to create/update if needed  
3. `list()` again to fetch the final project

**After**: 1 database roundtrip
1. `upsert()` handles both creation and updating with conflict resolution

## Test Plan

- [x] All existing tests pass (12/12)
- [x] Mock repository updated with new test scenarios
- [x] TypeScript compilation passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)