### PR TITLE
fix: improve ordering consistency across projects and sessions

### DIFF
--- a/src/actions/project.ts
+++ b/src/actions/project.ts
@@ -62,7 +62,7 @@ export async function listProjectsAction(query?: ListProjectQuery) {
       page: 1,
       limit: 100,
       order: "desc" as const,
-      orderBy: "updatedAt",
+      orderBy: "path",
     },
   };
   const result = await listProjects(context, query || defaultQuery);

--- a/src/core/adapters/drizzleSqlite/projectRepository.ts
+++ b/src/core/adapters/drizzleSqlite/projectRepository.ts
@@ -157,7 +157,7 @@ export class DrizzleSqliteProjectRepository implements ProjectRepository {
         case "updatedAt":
           return projects.updatedAt;
         default:
-          return projects.name; // Default to name ordering
+          return projects.path; // Default to path ordering
       }
     };
 

--- a/src/core/adapters/drizzleSqlite/sessionRepository.ts
+++ b/src/core/adapters/drizzleSqlite/sessionRepository.ts
@@ -208,12 +208,12 @@ export class DrizzleSqliteSessionRepository implements SessionRepository {
 
     // Special handling for lastMessageAt to put nulls last when descending, first when ascending
     if (pagination.orderBy === "lastMessageAt") {
-      if (pagination.order === "asc") {
-        // For asc order: nulls first, then non-null values (oldest messages first)
-        orderClause = sql`${orderColumn} ASC NULLS FIRST`;
-      } else {
+      if (pagination.order === "desc") {
         // For desc order: non-null values first (newest messages first), then nulls
         orderClause = sql`${orderColumn} DESC NULLS LAST`;
+      } else {
+        // For asc order: nulls first, then non-null values (oldest messages first)
+        orderClause = sql`${orderColumn} ASC NULLS FIRST`;
       }
     } else {
       orderClause =

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -27,8 +27,8 @@ export function useSessions({ limit: limitValue, projectId }: Args) {
         pagination: {
           page: p,
           limit,
-          order: "asc",
-          orderBy: "path",
+          order: "desc",
+          orderBy: "lastMessageAt",
         },
         filter: projectId && {
           projectId,


### PR DESCRIPTION
## Summary
- Change default project ordering from updatedAt to path for consistency
- Fix lastMessageAt ordering logic in session repository (desc: newest first, asc: oldest first)  
- Update session hook to use lastMessageAt desc ordering for better UX

## Test plan
- [ ] Verify projects are now ordered by path by default
- [ ] Test session ordering with lastMessageAt desc shows newest messages first
- [ ] Confirm ordering logic works correctly for both asc and desc directions

🤖 Generated with [Claude Code](https://claude.ai/code)