### PR TITLE
fix: replace Node.js glob with tinyglobby for better glob handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "recharts": "^2.15.3",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1",
+    "tinyglobby": "^0.2.14",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
     "zod": "^3.25.67"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      tinyglobby:
+        specifier: ^0.2.14
+        version: 0.2.14
       uuid:
         specifier: ^11.1.0
         version: 11.1.0

--- a/src/core/adapters/chokidar/fileWatcher.ts
+++ b/src/core/adapters/chokidar/fileWatcher.ts
@@ -1,8 +1,6 @@
-// @ts-ignore
-import { glob } from "node:fs/promises";
-import { join } from "node:path";
 import { type FSWatcher, watch } from "chokidar";
 import { err, ok, type Result } from "neverthrow";
+import { globSync } from "tinyglobby";
 import type {
   FileChangeHandler,
   FileWatcher,
@@ -26,17 +24,20 @@ export class ChokidarFileWatcher implements FileWatcher {
         });
       }
 
-      const watchPattern = join(config.targetDirectory, config.pattern);
-
-      this.watcher = watch(await Array.fromAsync(glob(watchPattern)), {
-        persistent: config.persistent,
-        ignoreInitial: config.ignoreInitial,
-        followSymlinks: false,
-        awaitWriteFinish: {
-          stabilityThreshold: config.stabilityThreshold,
-          pollInterval: config.pollInterval,
+      this.watcher = watch(
+        globSync([config.pattern], {
+          cwd: config.targetDirectory,
+        }),
+        {
+          persistent: config.persistent,
+          ignoreInitial: config.ignoreInitial,
+          followSymlinks: false,
+          awaitWriteFinish: {
+            stabilityThreshold: config.stabilityThreshold,
+            pollInterval: config.pollInterval,
+          },
         },
-      });
+      );
 
       this.watcher.on("add", async (filePath) => {
         await handler({

--- a/src/core/application/watcher/processLogFile.ts
+++ b/src/core/application/watcher/processLogFile.ts
@@ -12,7 +12,6 @@ import type {
   AssistantLog,
   ClaudeLogEntry,
   SummaryLog,
-  SystemLog,
   UserLog,
 } from "@/core/domain/watcher/types";
 import type { Context } from "../context";


### PR DESCRIPTION
## Summary
- Replace Node.js built-in `glob` with `tinyglobby` for more reliable glob functionality
- Update ChokidarFileWatcher to use `globSync` from tinyglobby package
- Remove unused `SystemLog` import from processLogFile
- Improve file watching pattern matching and performance

## Test plan
- [ ] Verify file watcher functionality still works correctly
- [ ] Test glob pattern matching with various patterns
- [ ] Ensure no breaking changes in file watching behavior

🤖 Generated with [Claude Code](https://claude.ai/code)