### PR TITLE
fix: refactor CLI setup and migration commands

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -3,7 +3,6 @@
 import "dotenv/config";
 import { spawn } from "node:child_process";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { cli, define } from "gunshi";
 import { batchProcessLogFiles } from "@/core/application/watcher";
 import { version } from "../../package.json";
@@ -16,13 +15,7 @@ import {
   loadConfig,
   saveConfig,
 } from "./config";
-
-function getProjectRoot(): string {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = path.dirname(__filename);
-  // From src/cli/cli.ts, go up two levels to reach project root
-  return path.resolve(__dirname, "../..");
-}
+import { getProjectRoot } from "./util";
 
 let isRunning = false;
 let intervalId: NodeJS.Timeout | null = null;
@@ -443,7 +436,7 @@ const setupCommand = define({
       console.log("Running database migrations...");
 
       const projectRoot = getProjectRoot();
-      const exitCode = await spawnCommand("npm", ["run", "db:migrate"], {
+      const exitCode = await spawnCommand("node", ["dist/cli/migrate.mjs"], {
         cwd: projectRoot,
       });
 

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,24 @@
+import * as path from "node:path";
+import "dotenv/config";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { getDatabase } from "@/core/adapters/drizzleSqlite/client";
+import { getConfigOrEnv } from "./config";
+import { getProjectRoot } from "./util";
+
+const { databaseFileName } = getConfigOrEnv();
+
+if (!databaseFileName) {
+  throw new Error(
+    "DATABASE_FILE_NAME not found in configuration or environment variables.",
+  );
+}
+
+const projectRoot = getProjectRoot();
+const db = getDatabase(databaseFileName);
+
+await migrate(db, {
+  migrationsFolder: path.join(
+    projectRoot,
+    "src/core/adapters/drizzleSqlite/migrations",
+  ),
+});

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -1,0 +1,8 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function getProjectRoot(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.resolve(__dirname, "../..");
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig([
       "./src/watcher/batchProcessor.ts",
       "./src/watcher/periodicBatchProcessor.ts",
       "./src/cli/cli.ts",
+      "./src/cli/migrate.ts",
     ],
     dts: true,
   },


### PR DESCRIPTION
## Summary
- Extract common utility functions to dedicated cli/util.ts module  
- Create standalone migrate.ts script for database migrations
- Update setup command to use built migration script instead of npm run command

## Test plan
- [ ] Verify CLI setup command works correctly
- [ ] Test database migration functionality
- [ ] Ensure build process includes new migrate.ts file

🤖 Generated with [Claude Code](https://claude.ai/code)