### PR TITLE
fix: remove unnecessary dotenv import from migrate.ts

### DIFF
--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,5 +1,4 @@
 import * as path from "node:path";
-import "dotenv/config";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import { getDatabase } from "@/core/adapters/drizzleSqlite/client";
 import { getConfigOrEnv } from "./config";


### PR DESCRIPTION
## Summary
- Remove unnecessary `dotenv/config` import from `src/cli/migrate.ts`
- Environment variables are already handled through the config system

## Test plan
- [x] Verify migrate command still works correctly
- [x] Confirm no functionality is broken by the removal

🤖 Generated with [Claude Code](https://claude.ai/code)