### PR TITLE
fix: use npm scripts instead of direct Next.js commands

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -348,15 +348,17 @@ const startCommand = define({
     const configuredPort = config?.port || 3000;
     const port = (argPort as number | undefined) || configuredPort;
 
+    const args = ["run", "start:web"];
+
     if (port !== 3000) {
-      args.push("--port", String(port));
+      args.push("--", "--port", String(port));
     }
 
     console.log(`Starting production server on port ${port}...`);
 
     try {
       const projectRoot = getProjectRoot();
-      const exitCode = await spawnCommand("npm", ["run", "start:web"], {
+      const exitCode = await spawnCommand("npm", args, {
         cwd: projectRoot,
       });
       process.exit(exitCode);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -348,8 +348,6 @@ const startCommand = define({
     const configuredPort = config?.port || 3000;
     const port = (argPort as number | undefined) || configuredPort;
 
-    const args = ["start"];
-
     if (port !== 3000) {
       args.push("--port", String(port));
     }
@@ -358,7 +356,9 @@ const startCommand = define({
 
     try {
       const projectRoot = getProjectRoot();
-      const exitCode = await spawnCommand("next", args, { cwd: projectRoot });
+      const exitCode = await spawnCommand("npm", ["run", "start:web"], {
+        cwd: projectRoot,
+      });
       process.exit(exitCode);
     } catch (error) {
       console.error("Failed to start production server:", error);
@@ -450,7 +450,7 @@ const setupCommand = define({
       console.log("");
       console.log("Building Next.js application...");
 
-      const buildExitCode = await spawnCommand("next", ["build"], {
+      const buildExitCode = await spawnCommand("npm", ["run", "build:web"], {
         cwd: projectRoot,
       });
 


### PR DESCRIPTION
## Summary
- Replace direct `next start` and `next build` commands with npm scripts
- Ensures proper environment setup and consistency with package.json scripts
- Fixes potential issues with command execution in different environments

## Test plan
- [ ] Verify `npm run start:web` works correctly
- [ ] Verify `npm run build:web` works correctly  
- [ ] Test CLI commands that use these updated scripts

🤖 Generated with [Claude Code](https://claude.ai/code)