### PR TITLE
fix: improve environment variable handling in CLI and context

### DIFF
--- a/src/actions/context.ts
+++ b/src/actions/context.ts
@@ -9,9 +9,6 @@ import type { Context } from "@/core/application/context";
 
 export const envSchema = z.object({
   DATABASE_FILE_NAME: z.string(),
-  // TURSO_DATABASE_URL: z.string(),
-  // TURSO_AUTH_TOKEN: z.string(),
-  // PGLITE_DATABASE_DIR: z.string(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -23,8 +20,6 @@ function getContext(): Context {
       `Invalid environment variables: ${JSON.stringify(env.error.errors)}`,
     );
   }
-
-  console.log(env.data.DATABASE_FILE_NAME);
 
   const db = getDatabase(env.data.DATABASE_FILE_NAME);
 


### PR DESCRIPTION
## Summary
- Remove unused environment variable comments and debug logging from context
- Fix port configuration in start command by using environment variables instead of CLI args
- Improve spawnCommand to support custom environment variables for better process isolation

## Test plan
- [ ] Test start command with default port (3000)
- [ ] Test start command with custom port configuration
- [ ] Verify environment variables are properly passed to spawned processes

🤖 Generated with [Claude Code](https://claude.ai/code)