### PR TITLE
fix: update CLI messages to use cc-jsonl command instead of npm

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -154,7 +154,7 @@ const batchCommand = define({
         "No configuration found. Please run 'setup' command first.",
       );
       console.error("");
-      console.error("Example: npm run cli setup");
+      console.error("Example: cc-jsonl setup");
       process.exit(1);
     }
 
@@ -245,7 +245,7 @@ const watchCommand = define({
         "No configuration found. Please run 'setup' command first.",
       );
       console.error("");
-      console.error("Example: npm run cli setup");
+      console.error("Example: cc-jsonl setup");
       process.exit(1);
     }
 
@@ -433,9 +433,9 @@ const setupCommand = define({
 
       console.log("");
       console.log("Setup completed! You can now run:");
-      console.log("  npm run logs:batch  - Process files once");
-      console.log("  npm run logs:watch  - Process files periodically");
-      console.log("  npm run start:prod  - Start production server");
+      console.log("  cc-jsonl batch  - Process files once");
+      console.log("  cc-jsonl watch  - Process files periodically");
+      console.log("  cc-jsonl start  - Start production server");
     } catch (error) {
       console.error("Setup failed:", error);
       process.exit(1);


### PR DESCRIPTION
## Summary

- CLIでエラーメッセージと設定完了メッセージにて `npm run cli` の代わりに `cc-jsonl` コマンドを使用するように修正
- `npm install -g cc-jsonl` でインストールしたユーザーに適切なコマンドが表示されるように変更

## Changes

- `src/cli/cli.ts` で以下のメッセージを修正:
  - `npm run cli setup` → `cc-jsonl setup`
  - `npm run logs:batch` → `cc-jsonl batch`
  - `npm run logs:watch` → `cc-jsonl watch`
  - `npm run start:prod` → `cc-jsonl start`

## Test plan

- [x] TypeScript型チェック実行
- [x] Biome lintチェック実行
- [x] Biome formatチェック実行

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)