### PR TITLE
feat: add bypassPermissions mode support

### DIFF
--- a/src/app/api/messages/stream/route.ts
+++ b/src/app/api/messages/stream/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: NextRequest) {
     const sessionId = searchParams.get("sessionId");
     const cwd = searchParams.get("cwd");
     const allowedToolsParam = searchParams.get("allowedTools");
+    const bypassPermissionsParam = searchParams.get("bypassPermissions");
 
     if (!message || typeof message !== "string") {
       return new Response("Valid message is required", { status: 400 });
@@ -35,6 +36,9 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Parse bypassPermissions if provided
+    const bypassPermissions = bypassPermissionsParam === "true";
+
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
@@ -49,6 +53,7 @@ export async function GET(request: NextRequest) {
               sessionId: sessionId || undefined,
               cwd: cwd || undefined,
               allowedTools,
+              bypassPermissions,
             },
             (chunk: ChunkData) => {
               try {

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { detectPermissionError } from "@/core/application/authorization/detectPermissionError";
 import { formatAllowedTool } from "@/core/application/authorization/formatAllowedTool";
@@ -59,6 +60,7 @@ export function ChatInterface({
   const [input, setInput] = useState("");
   const [currentCwd, setCurrentCwd] = useState(cwd || "");
   const [isLoading, setIsLoading] = useState(false);
+  const [bypassPermissions, setBypassPermissions] = useState(false);
   const [permissionRequest, setPermissionRequest] =
     useState<PermissionRequest | null>(null);
   const [showPermissionDialog, setShowPermissionDialog] = useState(false);
@@ -172,6 +174,9 @@ export function ChatInterface({
       }
       if (allowedTools) {
         url.searchParams.set("allowedTools", JSON.stringify(allowedTools));
+      }
+      if (bypassPermissions) {
+        url.searchParams.set("bypassPermissions", "true");
       }
 
       const eventSource = new EventSource(url.toString());
@@ -497,6 +502,19 @@ export function ChatInterface({
               />
             </div>
           )}
+
+          {/* Bypass Permissions Switch */}
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="bypass-permissions"
+              checked={bypassPermissions}
+              onCheckedChange={setBypassPermissions}
+              disabled={isLoading}
+            />
+            <Label htmlFor="bypass-permissions" className="text-sm font-medium">
+              Bypass Permissions
+            </Label>
+          </div>
 
           <div className="flex items-end gap-2 sm:gap-3 w-full">
             <Textarea

--- a/src/core/adapters/anthropic/claudeService.ts
+++ b/src/core/adapters/anthropic/claudeService.ts
@@ -26,6 +26,7 @@ export class AnthropicClaudeService implements ClaudeService {
         resume?: string;
         cwd?: string;
         allowedTools?: string[];
+        permissionMode?: "bypassPermissions";
       } = {
         pathToClaudeCodeExecutable: this.pathToClaudeCodeExecutable,
       };
@@ -43,6 +44,11 @@ export class AnthropicClaudeService implements ClaudeService {
       // Add allowed tools if provided
       if (input.allowedTools) {
         options.allowedTools = input.allowedTools;
+      }
+
+      // Add bypass permissions mode if provided
+      if (input.bypassPermissions) {
+        options.permissionMode = "bypassPermissions";
       }
 
       const messages: SDKMessage[] = [];

--- a/src/core/application/claude/sendMessageStream.ts
+++ b/src/core/application/claude/sendMessageStream.ts
@@ -14,6 +14,7 @@ export const sendMessageStreamInputSchema = z
     sessionId: z.string().min(1).optional(),
     cwd: z.string().min(1).optional(),
     allowedTools: z.array(z.string()).optional(),
+    bypassPermissions: z.boolean().optional(),
   })
   .refine(
     (data) => {
@@ -91,6 +92,7 @@ export async function sendMessageStream(
         sessionId: session?.id || undefined, // Use session ID for resuming, undefined for new sessions
         cwd: params.cwd || (session ? session.cwd : undefined),
         allowedTools: params.allowedTools,
+        bypassPermissions: params.bypassPermissions,
       },
       onChunk,
     );

--- a/src/core/domain/claude/types.ts
+++ b/src/core/domain/claude/types.ts
@@ -11,6 +11,7 @@ export const sendMessageInputSchema = z.object({
   sessionId: z.string().optional(),
   cwd: z.string().optional(),
   allowedTools: z.array(z.string()).optional(),
+  bypassPermissions: z.boolean().optional(),
 });
 export type SendMessageInput = z.infer<typeof sendMessageInputSchema>;
 


### PR DESCRIPTION
## Summary
- Add bypassPermissions field to SendMessageInput type and related schemas
- Update sendMessageStream application service to handle bypass mode parameter
- Implement bypass permissions support in AnthropicClaudeService adapter by setting permissionMode option
- Add bypass permissions toggle switch to ChatInterface UI
- Update streaming API endpoint to process bypassPermissions parameter

## Test plan
- [ ] Verify bypass permissions switch appears in chat interface
- [ ] Test that enabling bypass permissions passes the parameter through the entire stack
- [ ] Confirm Claude Code SDK receives permissionMode: "bypassPermissions" when enabled
- [ ] Validate that permission dialogs are bypassed when the mode is active

🤖 Generated with [Claude Code](https://claude.ai/code)