### PR TITLE
feat: add configurable pathToClaudeCodeExecutable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ cc-jsonl setup
 # Initialize with custom paths and port
 cc-jsonl setup --databaseFile /custom/path/data.db --watchDir /custom/logs --port 8080
 
+# Initialize with Claude Code executable path
+cc-jsonl setup --claudeCodeExecutable /usr/local/bin/claude
+
+# Use `which claude` to automatically set the Claude Code executable path
+cc-jsonl setup --claudeCodeExecutable "$(which claude)"
+
 # Force overwrite existing configuration (when config already exists)
 cc-jsonl setup --force
 ```
@@ -151,6 +157,7 @@ cc-jsonl watch --targetDirectory /path/to/claude-logs -p "**/*.jsonl" -i 15
 | `--databaseFile` | `-d` | Database file path | `$XDG_CONFIG_HOME/cc-jsonl/data.db` or `~/.config/cc-jsonl/data.db` |
 | `--watchDir` | `-w` | Directory to watch for log files | `$XDG_CONFIG_HOME/claude/projects` or `~/.claude/projects` |
 | `--port` | `-p` | Port for the production server | 3000 |
+| `--claudeCodeExecutable` | `-c` | Path to Claude Code executable (optional) | Not specified |
 | `--force` | `-f` | Force overwrite existing configuration | false |
 
 ### Production Server Options
@@ -199,7 +206,8 @@ cat ~/.config/cc-jsonl/settings.json
 {
   "databaseFileName": "/home/user/.config/cc-jsonl/data.db",
   "watchTargetDir": "/home/user/.claude/projects",
-  "port": 3000
+  "port": 3000,
+  "pathToClaudeCodeExecutable": "/usr/local/bin/claude"
 }
 ```
 
@@ -239,6 +247,9 @@ cc-jsonl setup
 
 # Custom setup with specific paths and port
 cc-jsonl setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude --port 8080
+
+# Custom setup with Claude Code executable path
+cc-jsonl setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude --port 8080 --claudeCodeExecutable "$(which claude)"
 ```
 
 ### Production Server Operations

--- a/src/actions/context.ts
+++ b/src/actions/context.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { getConfigOrEnv } from "@/cli/config";
 import { AnthropicClaudeService } from "@/core/adapters/anthropic/claudeService";
 import { getDatabase } from "@/core/adapters/drizzleSqlite/client";
 import { DrizzleSqliteLogFileTrackingRepository } from "@/core/adapters/drizzleSqlite/logFileTrackingRepository";
@@ -22,12 +23,15 @@ function getContext(): Context {
   }
 
   const db = getDatabase(env.data.DATABASE_FILE_NAME);
+  const config = getConfigOrEnv();
 
   return {
     projectRepository: new DrizzleSqliteProjectRepository(db),
     sessionRepository: new DrizzleSqliteSessionRepository(db),
     messageRepository: new DrizzleSqliteMessageRepository(db),
-    claudeService: new AnthropicClaudeService(), // Auto-detects Claude Code executable path
+    claudeService: new AnthropicClaudeService(
+      config.pathToClaudeCodeExecutable,
+    ),
     logFileTrackingRepository: new DrizzleSqliteLogFileTrackingRepository(db),
   };
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -373,6 +373,11 @@ const setupCommand = define({
       default: 3000,
       description: "Port for the production server",
     },
+    claudeCodeExecutable: {
+      type: "string",
+      short: "c",
+      description: "Path to Claude Code executable (optional)",
+    },
     force: {
       type: "boolean",
       short: "f",
@@ -381,7 +386,8 @@ const setupCommand = define({
     },
   },
   run: async (ctx) => {
-    const { databaseFile, watchDir, port, force } = ctx.values;
+    const { databaseFile, watchDir, port, claudeCodeExecutable, force } =
+      ctx.values;
 
     if (hasConfig() && !force) {
       console.error("Configuration already exists. Use --force to overwrite.");
@@ -395,6 +401,7 @@ const setupCommand = define({
       databaseFileName: (databaseFile as string) || defaultDbPath,
       watchTargetDir: (watchDir as string) || defaultWatchDir,
       port: (port as number) || 3000,
+      pathToClaudeCodeExecutable: claudeCodeExecutable as string | undefined,
     };
 
     console.log("Setting up Claude Code Watcher...");
@@ -403,6 +410,9 @@ const setupCommand = define({
     console.log(`  Database file: ${config.databaseFileName}`);
     console.log(`  Watch directory: ${config.watchTargetDir}`);
     console.log(`  Port: ${config.port}`);
+    console.log(
+      `  Claude Code executable: ${config.pathToClaudeCodeExecutable || "Not specified"}`,
+    );
     console.log("");
 
     try {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -7,6 +7,7 @@ export const configSchema = z.object({
   databaseFileName: z.string(),
   watchTargetDir: z.string(),
   port: z.number().default(3000),
+  pathToClaudeCodeExecutable: z.string().optional(),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -68,6 +69,7 @@ export function getConfigOrEnv(): {
   databaseFileName: string | undefined;
   watchTargetDir: string | undefined;
   port: number;
+  pathToClaudeCodeExecutable: string | undefined;
 } {
   const config = loadConfig();
 
@@ -76,6 +78,7 @@ export function getConfigOrEnv(): {
       databaseFileName: config.databaseFileName,
       watchTargetDir: config.watchTargetDir,
       port: config.port,
+      pathToClaudeCodeExecutable: config.pathToClaudeCodeExecutable,
     };
   }
 
@@ -83,5 +86,6 @@ export function getConfigOrEnv(): {
     databaseFileName: process.env.DATABASE_FILE_NAME,
     watchTargetDir: process.env.WATCH_TARGET_DIR,
     port: process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 3000,
+    pathToClaudeCodeExecutable: process.env.PATH_TO_CLAUDE_CODE_EXECUTABLE,
   };
 }

--- a/src/core/adapters/anthropic/claudeService.ts
+++ b/src/core/adapters/anthropic/claudeService.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { query } from "@anthropic-ai/claude-code";
 import { err, ok, type Result } from "neverthrow";
 import type { ClaudeService } from "@/core/domain/claude/ports/claudeService";
@@ -13,24 +12,11 @@ import { ClaudeError } from "@/lib/error";
 import { jsonValueSchema } from "@/lib/json";
 import { validate } from "@/lib/validation";
 
-// Get the path to the Claude Code executable using the `which claude` command
-function getClaudeCodeExecutablePath(): string | null {
-  try {
-    const path = execSync("which claude", { encoding: "utf8" }).trim();
-    return path || null;
-  } catch (error) {
-    console.warn("Failed to find claude executable path:", error);
-    return null;
-  }
-}
-
 export class AnthropicClaudeService implements ClaudeService {
   private readonly pathToClaudeCodeExecutable?: string;
 
   constructor(pathToClaudeCodeExecutable?: string) {
-    // If no path is provided, try to auto-detect it
-    this.pathToClaudeCodeExecutable =
-      pathToClaudeCodeExecutable || getClaudeCodeExecutablePath() || undefined;
+    this.pathToClaudeCodeExecutable = pathToClaudeCodeExecutable;
   }
 
   async sendMessageStream(


### PR DESCRIPTION
## Summary

- Remove automatic Claude Code executable path detection from AnthropicClaudeService using `which` command
- Add `pathToClaudeCodeExecutable` as optional configuration field in setup command
- Add `--claudeCodeExecutable` (`-c`) option to setup command for manual path specification
- Support `PATH_TO_CLAUDE_CODE_EXECUTABLE` environment variable as fallback
- Update README.md with comprehensive documentation and usage examples
- Maintain backward compatibility when executable path is undefined

## Test plan

- [x] Run type checking with `pnpm typecheck`
- [x] Run linting with `pnpm lint:fix`
- [x] Run formatting with `pnpm format`
- [ ] Test setup command with new `--claudeCodeExecutable` option
- [ ] Test setup command with `$(which claude)` pattern
- [ ] Verify configuration file includes new field when specified
- [ ] Verify undefined behavior when option not provided
- [ ] Test environment variable fallback functionality

## Changes

### Core Changes
- **AnthropicClaudeService**: Removed `which claude` auto-detection, simplified constructor
- **Config Schema**: Added optional `pathToClaudeCodeExecutable` field
- **Setup Command**: Added `--claudeCodeExecutable` (`-c`) option with validation
- **Context**: Updated to pass configured executable path to AnthropicClaudeService

### Documentation
- **README.md**: Added setup command examples with new option
- **README.md**: Updated configuration file format documentation
- **README.md**: Added command reference table entry for new option

Resolves #105

🤖 Generated with [Claude Code](https://claude.ai/code)