### PR TITLE
fix: set default pathToClaudeCodeExecutable to node_modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ cc-jsonl setup
 # Initialize with custom paths and port
 cc-jsonl setup --databaseFile /custom/path/data.db --watchDir /custom/logs --port 8080
 
-# Initialize with Claude Code executable path
-cc-jsonl setup --claudeCodeExecutable /usr/local/bin/claude
-
-# Use `which claude` to automatically set the Claude Code executable path
-cc-jsonl setup --claudeCodeExecutable "$(which claude)"
-
 # Force overwrite existing configuration (when config already exists)
 cc-jsonl setup --force
 ```
@@ -207,7 +201,7 @@ cat ~/.config/cc-jsonl/settings.json
   "databaseFileName": "/home/user/.config/cc-jsonl/data.db",
   "watchTargetDir": "/home/user/.claude/projects",
   "port": 3000,
-  "pathToClaudeCodeExecutable": "/usr/local/bin/claude"
+  "pathToClaudeCodeExecutable": "/path/to/node_modules/claude-code/cli.js"
 }
 ```
 
@@ -247,9 +241,6 @@ cc-jsonl setup
 
 # Custom setup with specific paths and port
 cc-jsonl setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude --port 8080
-
-# Custom setup with Claude Code executable path
-cc-jsonl setup --databaseFile /srv/data/claude.db --watchDir /var/log/claude --port 8080 --claudeCodeExecutable "$(which claude)"
 ```
 
 ### Production Server Operations

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,6 +11,7 @@ import {
   type Config,
   getDefaultDatabasePath,
   getDefaultTargetDir,
+  getDefaultPathToClaudeCodeExecutable,
   hasConfig,
   loadConfig,
   saveConfig,
@@ -396,12 +397,15 @@ const setupCommand = define({
 
     const defaultDbPath = getDefaultDatabasePath();
     const defaultWatchDir = getDefaultTargetDir();
+    const defaultPathToClaudeCodeExecutable =
+      getDefaultPathToClaudeCodeExecutable();
 
     const config: Config = {
       databaseFileName: (databaseFile as string) || defaultDbPath,
       watchTargetDir: (watchDir as string) || defaultWatchDir,
       port: (port as number) || 3000,
-      pathToClaudeCodeExecutable: claudeCodeExecutable as string | undefined,
+      pathToClaudeCodeExecutable:
+        (claudeCodeExecutable as string) || defaultPathToClaudeCodeExecutable,
     };
 
     console.log("Setting up Claude Code Watcher...");
@@ -411,7 +415,7 @@ const setupCommand = define({
     console.log(`  Watch directory: ${config.watchTargetDir}`);
     console.log(`  Port: ${config.port}`);
     console.log(
-      `  Claude Code executable: ${config.pathToClaudeCodeExecutable || "Not specified"}`,
+      `  Claude Code executable: ${config.pathToClaudeCodeExecutable}`,
     );
     console.log("");
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { z } from "zod";
+import { getProjectRoot } from "./util";
 
 export const configSchema = z.object({
   databaseFileName: z.string(),
@@ -31,6 +32,13 @@ export function getDefaultTargetDir(): string {
     return path.join(xdgConfigHome, "claude", "projects");
   }
   return path.join(os.homedir(), ".claude", "projects");
+}
+
+export function getDefaultPathToClaudeCodeExecutable(): string {
+  return path.join(
+    getProjectRoot(),
+    "node_modules/@anthropic-ai/claude-code/cli.js",
+  );
 }
 
 export function loadConfig(): Config | null {


### PR DESCRIPTION
## Summary
- Add default path resolution for Claude Code executable to avoid manual configuration
- Remove documentation for claudeCodeExecutable option since it now has a sensible default  
- Update configuration examples to reflect the new default behavior

## Test plan
- [ ] Verify `cc-jsonl setup` works without --claudeCodeExecutable flag
- [ ] Confirm the default path points to node_modules/@anthropic-ai/claude-code/cli.js
- [ ] Test that manual --claudeCodeExecutable override still works

🤖 Generated with [Claude Code](https://claude.ai/code)