### PR TITLE
fix: move pathToClaudeCodeExecutable from config to environment variable

### DIFF
--- a/src/actions/context.ts
+++ b/src/actions/context.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { getConfigOrEnv } from "@/cli/config";
 import { AnthropicClaudeService } from "@/core/adapters/anthropic/claudeService";
 import { getDatabase } from "@/core/adapters/drizzleSqlite/client";
 import { DrizzleSqliteLogFileTrackingRepository } from "@/core/adapters/drizzleSqlite/logFileTrackingRepository";
@@ -10,6 +9,7 @@ import type { Context } from "@/core/application/context";
 
 export const envSchema = z.object({
   DATABASE_FILE_NAME: z.string(),
+  PATH_TO_CLAUDE_CODE_EXECUTABLE: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -23,14 +23,13 @@ function getContext(): Context {
   }
 
   const db = getDatabase(env.data.DATABASE_FILE_NAME);
-  const config = getConfigOrEnv();
 
   return {
     projectRepository: new DrizzleSqliteProjectRepository(db),
     sessionRepository: new DrizzleSqliteSessionRepository(db),
     messageRepository: new DrizzleSqliteMessageRepository(db),
     claudeService: new AnthropicClaudeService(
-      config.pathToClaudeCodeExecutable,
+      env.data.PATH_TO_CLAUDE_CODE_EXECUTABLE,
     ),
     logFileTrackingRepository: new DrizzleSqliteLogFileTrackingRepository(db),
   };

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,7 +11,6 @@ import {
   type Config,
   getDefaultDatabasePath,
   getDefaultTargetDir,
-  getDefaultPathToClaudeCodeExecutable,
   hasConfig,
   loadConfig,
   saveConfig,
@@ -327,6 +326,11 @@ const startCommand = define({
   run: async (ctx) => {
     const { port: argPort } = ctx.values;
 
+    const pathToClaudeCodeExecutable = path.join(
+      getProjectRoot(),
+      "node_modules/@authropic-ai/claude-code/cli.js",
+    );
+
     // Load configuration to get the port setting
     const config = loadConfig();
     const configuredPort = config?.port || 3000;
@@ -342,6 +346,7 @@ const startCommand = define({
           PORT: String(port),
           DATABASE_FILE_NAME:
             config?.databaseFileName || getDefaultDatabasePath(),
+          PATH_TO_CLAUDE_CODE_EXECUTABLE: pathToClaudeCodeExecutable,
         },
       });
       process.exit(exitCode);
@@ -374,11 +379,6 @@ const setupCommand = define({
       default: 3000,
       description: "Port for the production server",
     },
-    claudeCodeExecutable: {
-      type: "string",
-      short: "c",
-      description: "Path to Claude Code executable (optional)",
-    },
     force: {
       type: "boolean",
       short: "f",
@@ -387,8 +387,7 @@ const setupCommand = define({
     },
   },
   run: async (ctx) => {
-    const { databaseFile, watchDir, port, claudeCodeExecutable, force } =
-      ctx.values;
+    const { databaseFile, watchDir, port, force } = ctx.values;
 
     if (hasConfig() && !force) {
       console.error("Configuration already exists. Use --force to overwrite.");
@@ -397,15 +396,11 @@ const setupCommand = define({
 
     const defaultDbPath = getDefaultDatabasePath();
     const defaultWatchDir = getDefaultTargetDir();
-    const defaultPathToClaudeCodeExecutable =
-      getDefaultPathToClaudeCodeExecutable();
 
     const config: Config = {
       databaseFileName: (databaseFile as string) || defaultDbPath,
       watchTargetDir: (watchDir as string) || defaultWatchDir,
       port: (port as number) || 3000,
-      pathToClaudeCodeExecutable:
-        (claudeCodeExecutable as string) || defaultPathToClaudeCodeExecutable,
     };
 
     console.log("Setting up Claude Code Watcher...");
@@ -414,9 +409,6 @@ const setupCommand = define({
     console.log(`  Database file: ${config.databaseFileName}`);
     console.log(`  Watch directory: ${config.watchTargetDir}`);
     console.log(`  Port: ${config.port}`);
-    console.log(
-      `  Claude Code executable: ${config.pathToClaudeCodeExecutable}`,
-    );
     console.log("");
 
     try {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { z } from "zod";
-import { getProjectRoot } from "./util";
 
 export const configSchema = z.object({
   databaseFileName: z.string(),
@@ -32,13 +31,6 @@ export function getDefaultTargetDir(): string {
     return path.join(xdgConfigHome, "claude", "projects");
   }
   return path.join(os.homedir(), ".claude", "projects");
-}
-
-export function getDefaultPathToClaudeCodeExecutable(): string {
-  return path.join(
-    getProjectRoot(),
-    "node_modules/@anthropic-ai/claude-code/cli.js",
-  );
 }
 
 export function loadConfig(): Config | null {


### PR DESCRIPTION
## Summary
- Move pathToClaudeCodeExecutable setting from config to environment variable
- Remove pathToClaudeCodeExecutable from config schema and setup command
- Set pathToClaudeCodeExecutable in start command environment variables
- Simplify configuration by removing dependency on config file for this setting

## Test plan
- [ ] Verify the watcher starts correctly with the new environment variable approach
- [ ] Confirm that Claude Code executable path is properly resolved
- [ ] Test that existing config files work without the removed field

🤖 Generated with [Claude Code](https://claude.ai/code)