### PR TITLE
fix: correct typo in package name from @authropic-ai to @anthropic-ai

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -328,7 +328,7 @@ const startCommand = define({
 
     const pathToClaudeCodeExecutable = path.join(
       getProjectRoot(),
-      "node_modules/@authropic-ai/claude-code/cli.js",
+      "node_modules/@anthropic-ai/claude-code/cli.js",
     );
 
     // Load configuration to get the port setting


### PR DESCRIPTION
## Summary
• Fixed typo in package name from `@authropic-ai` to `@anthropic-ai` in CLI executable path

## Test plan
- [ ] Verify the application starts correctly with the corrected package name
- [ ] Test that Claude Code executable is found at the correct path

🤖 Generated with [Claude Code](https://claude.ai/code)