### PR TITLE
fix: include node_modules/@anthropic-ai/claude-code in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "files": [
     ".next",
     "dist",
+    "node_modules/@anthropic-ai/claude-code",
     "src/core/adapters/drizzleSqlite/migrations"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
• Include node_modules/@anthropic-ai/claude-code in package.json files array to ensure the dependency is packaged correctly

## Test plan
- [ ] Verify package builds correctly with included files
- [ ] Test that @anthropic-ai/claude-code dependency is available in published package

🤖 Generated with [Claude Code](https://claude.ai/code)