### PR TITLE
fix: prevent mobile zoom on input field

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -500,7 +500,7 @@ export function ChatInterface({
                 value={currentCwd}
                 onChange={(e) => setCurrentCwd(e.target.value)}
                 placeholder="/path/to/your/project"
-                className="mt-2 bg-background"
+                className="mt-2 bg-background !text-[16px]"
                 disabled={isLoading}
               />
             </div>


### PR DESCRIPTION
## Summary
- Fixed iOS mobile zoom issue by adding explicit font size to input field in ChatInterface

## Test plan
- [ ] Test on iOS Safari that input field no longer triggers zoom when focused
- [ ] Verify input field styling remains consistent across devices
- [ ] Test chat interface functionality on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)