### PR TITLE
Release v1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-jsonl",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Unified CLI for Claude Code production server and log processing",
   "author": "maku.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fix mobile zoom prevention on input field in ChatInterface
- Bump version to 1.2.9

## Test plan
- [ ] Verify mobile input fields don't trigger zoom
- [ ] Test chat interface functionality on mobile devices
- [ ] Confirm version update is correct

🤖 Generated with [Claude Code](https://claude.ai/code)