### PR TITLE
fix: handle null projectId in session page navigation

### DIFF
--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -25,7 +25,9 @@ export default async function SessionPage({ params }: PageProps) {
   });
 
   return (
-    <PageLayout returnTo={`/projects/${session.projectId}`}>
+    <PageLayout
+      returnTo={session.projectId ? `/projects/${session.projectId}` : "/"}
+    >
       <ChatInterface
         sessionId={sessionId}
         projectId={session.projectId || undefined}


### PR DESCRIPTION
## Summary
- Add null check for session.projectId in session page navigation
- Prevent navigation to invalid project URLs when projectId is null
- Return button now navigates to root page instead of broken project URL

## Test plan
- [ ] Test session page with null projectId
- [ ] Verify return button navigates to root page
- [ ] Test session page with valid projectId still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)