### PR TITLE
feat: add support for negatable skipExisting flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cc-jsonl batch --targetDirectory /path/to/claude-logs
 cc-jsonl batch --targetDirectory /path/to/claude-logs -c 10 -p "*.jsonl"
 
 # Reprocess all files including already processed ones
-cc-jsonl batch --targetDirectory /path/to/claude-logs --skipExisting false
+cc-jsonl batch --targetDirectory /path/to/claude-logs --no-skipExisting
 
 # Process only specific pattern files
 cc-jsonl batch --targetDirectory /path/to/claude-logs --pattern "session-*.jsonl"
@@ -180,6 +180,7 @@ cc-jsonl watch --targetDirectory /path/to/claude-logs -p "**/*.jsonl" -i 15
 | `--targetDirectory` | - | Directory to process | Uses configured watch directory or WATCH_TARGET_DIR |
 | `--maxConcurrency` | `-c` | Maximum concurrent processing | 5 |
 | `--skipExisting` | `-s` | Skip already processed files | true |
+| `--no-skipExisting` | | Do not skip already processed files | |
 | `--pattern` | `-p` | File pattern to match | `**/*.jsonl` |
 
 **Watch Command Options:**
@@ -189,6 +190,7 @@ cc-jsonl watch --targetDirectory /path/to/claude-logs -p "**/*.jsonl" -i 15
 | `--targetDirectory` | - | Directory to process | Uses configured watch directory or WATCH_TARGET_DIR |
 | `--maxConcurrency` | `-c` | Maximum concurrent processing | 5 |
 | `--skipExisting` | `-s` | Skip already processed files | true |
+| `--no-skipExisting` | | Do not skip already processed files | |
 | `--pattern` | `-p` | File pattern to match | `**/*.jsonl` |
 | `--interval` | `-i` | Processing interval in minutes | 60 |
 
@@ -273,7 +275,7 @@ cc-jsonl start --port 8080
 
 ```bash
 # Process large backlog of accumulated logs
-cc-jsonl batch --targetDirectory /archive/claude-logs -c 15 --skipExisting false
+cc-jsonl batch --targetDirectory /archive/claude-logs -c 15 --no-skipExisting
 ```
 
 #### Real-time Monitoring

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-jsonl",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Unified CLI for Claude Code production server and log processing",
   "author": "maku.",
   "license": "MIT",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -137,6 +137,7 @@ const batchCommand = define({
     },
     skipExisting: {
       type: "boolean",
+      negatable: true,
       short: "s",
       default: true,
       description: "Skip files that have already been processed",
@@ -222,6 +223,7 @@ const watchCommand = define({
     },
     skipExisting: {
       type: "boolean",
+      negatable: true,
       short: "s",
       default: true,
       description: "Skip files that have already been processed",


### PR DESCRIPTION
## Summary
- Add `negatable: true` to skipExisting flag in both batch and watch commands
- Update documentation to show `--no-skipExisting` usage instead of `--skipExisting false`
- Bump version to 1.3.1 to reflect this CLI improvement

## Test plan
- [ ] Verify `--no-skipExisting` flag works correctly in batch command
- [ ] Verify `--no-skipExisting` flag works correctly in watch command  
- [ ] Confirm original `--skipExisting` flag still works as expected
- [ ] Test that default behavior (skipExisting=true) remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)